### PR TITLE
Fix CSP handling so login pages keep SvelteKit inline script support

### DIFF
--- a/web/src/hooks.server.test.ts
+++ b/web/src/hooks.server.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, mock, test } from "bun:test";
+import { isProtectedRoute } from "./lib/utils/routes";
+
+mock.module("$lib/utils/routes", () => ({
+    isProtectedRoute,
+}));
+
+describe("security headers", () => {
+    test("preserves SvelteKit's generated CSP sources", async () => {
+        const { handle } = await import("./hooks.server");
+        const event = {
+            cookies: {
+                get: () => undefined,
+            },
+            request: new Request("http://localhost/"),
+            url: new URL("http://localhost/"),
+        } as unknown as Parameters<typeof handle>[0]["event"];
+        const response = await handle({
+            event,
+            resolve: async () => {
+                return new Response("", {
+                    headers: {
+                        "Content-Security-Policy":
+                            "script-src 'self' 'nonce-sveltekit-generated'",
+                    },
+                });
+            },
+        });
+
+        expect(response.headers.get("Content-Security-Policy")).toBe(
+            "script-src 'self' 'nonce-sveltekit-generated'",
+        );
+        expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    });
+
+    test("adds a fallback CSP when SvelteKit did not generate one", async () => {
+        const { handle } = await import("./hooks.server");
+        const event = {
+            cookies: {
+                get: () => undefined,
+            },
+            request: new Request("http://localhost/health"),
+            url: new URL("http://localhost/health"),
+        } as unknown as Parameters<typeof handle>[0]["event"];
+        const response = await handle({
+            event,
+            resolve: async () =>
+                new Response("{}", { headers: { "Content-Type": "application/json" } }),
+        });
+
+        expect(response.headers.get("Content-Security-Policy")).toContain(
+            "script-src 'self'",
+        );
+        expect(response.headers.get("Content-Security-Policy")).toContain(
+            "object-src 'none'",
+        );
+    });
+});

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -1,20 +1,7 @@
 import type { Handle } from "@sveltejs/kit";
 import { redirect } from "@sveltejs/kit";
 import { isProtectedRoute } from "$lib/utils/routes";
-
-const csp = [
-    "default-src 'self'",
-    "base-uri 'self'",
-    "object-src 'none'",
-    "frame-ancestors 'none'",
-    "form-action 'self'",
-    "script-src 'self'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self' https: wss:",
-    "upgrade-insecure-requests",
-].join("; ");
+import { cspHeaderValue } from "$lib/server/csp.js";
 
 export const handle: Handle = async ({ event, resolve }) => {
     const sessionCookie = event.cookies.get("keycastUserPubkey");
@@ -24,7 +11,9 @@ export const handle: Handle = async ({ event, resolve }) => {
 
     const response = await resolve(event);
 
-    response.headers.set("Content-Security-Policy", csp);
+    if (!response.headers.has("Content-Security-Policy")) {
+        response.headers.set("Content-Security-Policy", cspHeaderValue);
+    }
     response.headers.set("X-Content-Type-Options", "nosniff");
     response.headers.set("X-Frame-Options", "DENY");
     response.headers.set("Referrer-Policy", "no-referrer");

--- a/web/src/lib/server/csp.js
+++ b/web/src/lib/server/csp.js
@@ -1,0 +1,45 @@
+const quotedSources = new Set([
+    "self",
+    "none",
+    "unsafe-inline",
+    "unsafe-eval",
+    "wasm-unsafe-eval",
+    "strict-dynamic",
+    "report-sample",
+]);
+
+/** @typedef {Record<string, string[] | true>} CspDirectiveMap */
+
+/** @type {CspDirectiveMap} */
+export const cspDirectives = {
+    "default-src": ["self"],
+    "base-uri": ["self"],
+    "object-src": ["none"],
+    "frame-ancestors": ["none"],
+    "form-action": ["self"],
+    "script-src": ["self"],
+    "style-src": ["self", "unsafe-inline"],
+    "img-src": ["self", "data:"],
+    "font-src": ["self", "data:"],
+    "connect-src": ["self", "https:", "wss:"],
+    "upgrade-insecure-requests": true,
+};
+
+/** @param {string} source */
+const formatSource = (source) => {
+    if (quotedSources.has(source)) {
+        return `'${source}'`;
+    }
+
+    return source;
+};
+
+export const cspHeaderValue = Object.entries(cspDirectives)
+    .map(([directive, value]) => {
+        if (value === true) {
+            return directive;
+        }
+
+        return `${directive} ${value.map(formatSource).join(" ")}`;
+    })
+    .join("; ");

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -1,5 +1,6 @@
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import adapter from "svelte-adapter-bun";
+import { cspDirectives } from "./src/lib/server/csp.js";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -12,6 +13,9 @@ const config = {
         // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
         // See https://svelte.dev/docs/kit/adapters for more information about adapters.
         adapter: adapter(),
+        csp: {
+            directives: cspDirectives,
+        },
     },
 };
 


### PR DESCRIPTION
## Summary
- Move CSP directive definition into `svelte.config.js` so SvelteKit can attach the nonce/hash sources it needs for inline bootstrap scripts.
- Stop overwriting `Content-Security-Policy` in the server hook when SvelteKit has already generated one.
- Keep a fallback CSP for responses that do not get a framework-generated policy, and add regression coverage for both cases.

## Testing
- `cd web && bun test`
- `cd web && bun run check`
- `cd web && bun run build`
- Local browser smoke test against the built app confirmed the login page renders and the response CSP includes a nonce on HTML pages.