### PR TITLE
Improve authorization management

### DIFF
--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -34,6 +34,10 @@ fn protected_routes(pool: SqlitePool) -> Router {
             "/teams/:id/keys/:pubkey/authorizations",
             post(teams::add_authorization),
         )
+        .route(
+            "/teams/:id/keys/:pubkey/authorizations/:authorization_id",
+            delete(teams::remove_authorization),
+        )
         .route("/teams/:id/policies", post(teams::add_policy))
         .layer(middleware::from_fn(auth_middleware))
         .with_state(pool)

--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -564,6 +564,7 @@ pub async fn add_authorization(
     Json(request): Json<AddAuthorizationRequest>,
 ) -> ApiResult<Json<Authorization>> {
     verify_admin(&pool, &event.pubkey, team_id).await?;
+    let authorization_name = normalized_authorization_name(request.name.as_deref());
 
     let stored_key_public_key =
         PublicKey::from_hex(&pubkey).map_err(|e| ApiError::bad_request(e.to_string()))?;
@@ -612,12 +613,13 @@ pub async fn add_authorization(
     // Create authorization
     let authorization = sqlx::query_as::query_as::<_, Authorization>(
             r#"
-            INSERT INTO authorizations (stored_key_id, policy_id, secret, bunker_public_key, bunker_secret, relays, max_uses, expires_at, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'), datetime('now'))
+            INSERT INTO authorizations (stored_key_id, name, policy_id, secret, bunker_public_key, bunker_secret, relays, max_uses, expires_at, created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, datetime('now'), datetime('now'))
             RETURNING *
             "#,
         )
         .bind(stored_key.id)
+        .bind(authorization_name)
         .bind(request.policy_id)
         .bind(secret)
         .bind(bunker_keys.public_key().to_hex())
@@ -631,6 +633,59 @@ pub async fn add_authorization(
     tx.commit().await?;
 
     Ok(Json(authorization))
+}
+
+pub async fn remove_authorization(
+    State(pool): State<SqlitePool>,
+    AuthEvent(event): AuthEvent,
+    Path((team_id, pubkey, authorization_id)): Path<(u32, String, u32)>,
+) -> ApiResult<StatusCode> {
+    verify_admin(&pool, &event.pubkey, team_id).await?;
+
+    let stored_key_public_key =
+        PublicKey::from_hex(&pubkey).map_err(|e| ApiError::bad_request(e.to_string()))?;
+
+    let mut tx = pool.begin().await?;
+
+    let existing_authorization_id: Option<u32> = sqlx::query_scalar::query_scalar(
+        r#"
+        SELECT a.id
+        FROM authorizations a
+        JOIN stored_keys sk ON sk.id = a.stored_key_id
+        WHERE a.id = ?1
+          AND sk.team_id = ?2
+          AND sk.public_key = ?3
+        "#,
+    )
+    .bind(authorization_id)
+    .bind(team_id)
+    .bind(stored_key_public_key.to_hex())
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    if existing_authorization_id.is_none() {
+        return Err(ApiError::not_found("Authorization not found"));
+    }
+
+    sqlx::query::query("DELETE FROM user_authorizations WHERE authorization_id = ?1")
+        .bind(authorization_id)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query::query("DELETE FROM authorizations WHERE id = ?1")
+        .bind(authorization_id)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn normalized_authorization_name(name: Option<&str>) -> Option<String> {
+    name.map(str::trim)
+        .filter(|trimmed| !trimmed.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 pub async fn add_policy(
@@ -718,10 +773,26 @@ pub async fn verify_admin<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::{KeycastState, KEYCAST_STATE};
     use axum::extract::Path;
+    use keycast_core::encryption::{KeyManager, KeyManagerError};
     use keycast_core::types::user::TeamUserRole;
     use sqlx::raw_sql::raw_sql;
     use sqlx_sqlite::SqlitePoolOptions;
+    use std::sync::Arc;
+
+    struct TestKeyManager;
+
+    #[async_trait::async_trait]
+    impl KeyManager for TestKeyManager {
+        async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+            Ok(plaintext_bytes.to_vec())
+        }
+
+        async fn decrypt(&self, ciphertext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+            Ok(ciphertext_bytes.to_vec())
+        }
+    }
 
     async fn setup_test_db() -> SqlitePool {
         let pool = SqlitePoolOptions::new()
@@ -740,6 +811,17 @@ mod tests {
         .execute(&pool)
         .await
         .unwrap();
+        raw_sql(include_str!(
+            "../../../../database/migrations/0003_add_authorization_name.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let _ = KEYCAST_STATE.set(Arc::new(KeycastState {
+            db: pool.clone(),
+            key_manager: Box::new(TestKeyManager),
+        }));
 
         pool
     }
@@ -901,6 +983,7 @@ mod tests {
             AuthEvent(auth_event(&admin)),
             Path((first_team.team.id, stored_key.public_key().to_hex())),
             Json(AddAuthorizationRequest {
+                name: Some("Other team policy".to_string()),
                 policy_id: second_team.policies[0].policy.id,
                 relays: vec!["wss://relay.example".to_string()],
                 max_uses: None,
@@ -912,6 +995,212 @@ mod tests {
 
         assert!(matches!(err, ApiError::NotFound(_)));
         assert_eq!(count_rows(&pool, "authorizations").await, 0);
+    }
+
+    #[tokio::test]
+    async fn add_authorization_persists_trimmed_name() {
+        let pool = setup_test_db().await;
+        let admin = Keys::generate();
+        let team = create_team_for(&pool, &admin, "Ops").await;
+        let stored_key = Keys::generate();
+
+        sqlx::query::query(
+            "INSERT INTO stored_keys (name, team_id, public_key, secret_key, created_at, updated_at)
+             VALUES ('key', ?1, ?2, ?3, datetime('now'), datetime('now'))",
+        )
+        .bind(team.team.id)
+        .bind(stored_key.public_key().to_hex())
+        .bind(vec![1_u8, 2, 3])
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let authorization = add_authorization(
+            State(pool.clone()),
+            AuthEvent(auth_event(&admin)),
+            Path((team.team.id, stored_key.public_key().to_hex())),
+            Json(AddAuthorizationRequest {
+                name: Some("  Alice tablet  ".to_string()),
+                policy_id: team.policies[0].policy.id,
+                relays: vec!["wss://relay.example".to_string()],
+                max_uses: None,
+                expires_at: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+
+        assert_eq!(authorization.name.as_deref(), Some("Alice tablet"));
+
+        let stored_name: Option<String> =
+            sqlx::query_scalar::query_scalar("SELECT name FROM authorizations WHERE id = ?1")
+                .bind(authorization.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(stored_name.as_deref(), Some("Alice tablet"));
+    }
+
+    #[tokio::test]
+    async fn remove_authorization_deletes_selected_authorization_and_redemptions_only() {
+        let pool = setup_test_db().await;
+        let admin = Keys::generate();
+        let team = create_team_for(&pool, &admin, "Ops").await;
+        let stored_key = Keys::generate();
+        let auth_user = Keys::generate();
+
+        sqlx::query::query(
+            "INSERT INTO stored_keys (name, team_id, public_key, secret_key, created_at, updated_at)
+             VALUES ('key', ?1, ?2, ?3, datetime('now'), datetime('now'))",
+        )
+        .bind(team.team.id)
+        .bind(stored_key.public_key().to_hex())
+        .bind(vec![1_u8, 2, 3])
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let first = add_authorization(
+            State(pool.clone()),
+            AuthEvent(auth_event(&admin)),
+            Path((team.team.id, stored_key.public_key().to_hex())),
+            Json(AddAuthorizationRequest {
+                name: Some("Alice phone".to_string()),
+                policy_id: team.policies[0].policy.id,
+                relays: vec!["wss://relay.example".to_string()],
+                max_uses: None,
+                expires_at: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        let second = add_authorization(
+            State(pool.clone()),
+            AuthEvent(auth_event(&admin)),
+            Path((team.team.id, stored_key.public_key().to_hex())),
+            Json(AddAuthorizationRequest {
+                name: Some("Bob laptop".to_string()),
+                policy_id: team.policies[0].policy.id,
+                relays: vec!["wss://relay.example".to_string()],
+                max_uses: None,
+                expires_at: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+
+        sqlx::query::query(
+            "INSERT INTO users (public_key, created_at, updated_at)
+             VALUES (?1, datetime('now'), datetime('now'))",
+        )
+        .bind(auth_user.public_key().to_hex())
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query::query(
+            "INSERT INTO user_authorizations (user_public_key, authorization_id, created_at, updated_at)
+             VALUES (?1, ?2, datetime('now'), datetime('now'))",
+        )
+        .bind(auth_user.public_key().to_hex())
+        .bind(first.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let status = remove_authorization(
+            State(pool.clone()),
+            AuthEvent(auth_event(&admin)),
+            Path((team.team.id, stored_key.public_key().to_hex(), first.id)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let first_count: i64 =
+            sqlx::query_scalar::query_scalar("SELECT COUNT(*) FROM authorizations WHERE id = ?1")
+                .bind(first.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let second_count: i64 =
+            sqlx::query_scalar::query_scalar("SELECT COUNT(*) FROM authorizations WHERE id = ?1")
+                .bind(second.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let redemption_count: i64 = sqlx::query_scalar::query_scalar(
+            "SELECT COUNT(*) FROM user_authorizations WHERE authorization_id = ?1",
+        )
+        .bind(first.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(first_count, 0);
+        assert_eq!(second_count, 1);
+        assert_eq!(redemption_count, 0);
+    }
+
+    #[tokio::test]
+    async fn remove_authorization_rejects_authorization_from_another_key_path() {
+        let pool = setup_test_db().await;
+        let admin = Keys::generate();
+        let team = create_team_for(&pool, &admin, "Ops").await;
+        let first_key = Keys::generate();
+        let second_key = Keys::generate();
+
+        for key in [&first_key, &second_key] {
+            sqlx::query::query(
+                "INSERT INTO stored_keys (name, team_id, public_key, secret_key, created_at, updated_at)
+                 VALUES ('key', ?1, ?2, ?3, datetime('now'), datetime('now'))",
+            )
+            .bind(team.team.id)
+            .bind(key.public_key().to_hex())
+            .bind(vec![1_u8, 2, 3])
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let authorization = add_authorization(
+            State(pool.clone()),
+            AuthEvent(auth_event(&admin)),
+            Path((team.team.id, first_key.public_key().to_hex())),
+            Json(AddAuthorizationRequest {
+                name: Some("Alice phone".to_string()),
+                policy_id: team.policies[0].policy.id,
+                relays: vec!["wss://relay.example".to_string()],
+                max_uses: None,
+                expires_at: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+
+        let err = remove_authorization(
+            State(pool.clone()),
+            AuthEvent(auth_event(&admin)),
+            Path((
+                team.team.id,
+                second_key.public_key().to_hex(),
+                authorization.id,
+            )),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, ApiError::NotFound(_)));
+        let authorization_count: i64 =
+            sqlx::query_scalar::query_scalar("SELECT COUNT(*) FROM authorizations WHERE id = ?1")
+                .bind(authorization.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(authorization_count, 1);
     }
 
     #[tokio::test]

--- a/api/src/api/types.rs
+++ b/api/src/api/types.rs
@@ -40,6 +40,8 @@ pub struct CreatePolicyRequest {
 
 #[derive(Debug, Deserialize)]
 pub struct AddAuthorizationRequest {
+    #[serde(default)]
+    pub name: Option<String>,
     pub policy_id: u32,
     pub relays: Vec<String>,
     pub max_uses: Option<i32>,

--- a/core/src/database.rs
+++ b/core/src/database.rs
@@ -158,6 +158,7 @@ mod tests {
             &migrations_dir,
             "0002_normalize_allowed_kinds_permissions.sql",
         );
+        copy_migration(&migrations_dir, "0003_add_authorization_name.sql");
 
         let database = Database::new(db_path.clone(), migrations_dir.clone())
             .await
@@ -169,7 +170,7 @@ mod tests {
                 .fetch_all(pool)
                 .await
                 .expect("read migration versions");
-        assert_eq!(migration_versions, vec![1, 2]);
+        assert_eq!(migration_versions, vec![1, 2, 3]);
 
         let migrated_config: serde_json::Value = query_scalar(
             "SELECT config FROM permissions
@@ -195,8 +196,8 @@ mod tests {
         .expect("read current-shape config");
         assert_eq!(current_shape_config, json!({ "allowed_kinds": [9735] }));
 
-        let existing_authorization: (String, i64, String) = query_as(
-            "SELECT secret, max_uses, bunker_public_key FROM authorizations WHERE secret = ?",
+        let existing_authorization: (String, i64, String, Option<String>) = query_as(
+            "SELECT secret, max_uses, bunker_public_key, name FROM authorizations WHERE secret = ?",
         )
         .bind("existing-secret")
         .fetch_one(pool)
@@ -207,7 +208,8 @@ mod tests {
             (
                 "existing-secret".to_string(),
                 10,
-                "existing-bunker-pubkey".to_string()
+                "existing-bunker-pubkey".to_string(),
+                None
             )
         );
 
@@ -227,7 +229,7 @@ mod tests {
                 .fetch_all(&database.pool)
                 .await
                 .expect("read migration versions after second open");
-        assert_eq!(migration_versions, vec![1, 2]);
+        assert_eq!(migration_versions, vec![1, 2, 3]);
         database.pool.close().await;
 
         let _ = fs::remove_dir_all(root);

--- a/core/src/types/authorization.rs
+++ b/core/src/types/authorization.rs
@@ -71,6 +71,8 @@ pub struct Authorization {
     pub id: u32,
     /// The id of the stored key the authorization belongs to
     pub stored_key_id: u32,
+    /// A human-readable label for remembering what the authorization is for
+    pub name: Option<String>,
     /// The generated secret connection uuid
     pub secret: String,
     /// The public key of the bunker nostr secret key
@@ -102,6 +104,7 @@ impl<'r> FromRow<'r, SqliteRow> for Authorization {
         Ok(Self {
             id: row.try_get("id")?,
             stored_key_id: row.try_get("stored_key_id")?,
+            name: row.try_get("name")?,
             secret: row.try_get("secret")?,
             bunker_public_key: row.try_get("bunker_public_key")?,
             bunker_secret: row.try_get("bunker_secret")?,
@@ -476,6 +479,12 @@ mod tests {
         .execute(&pool)
         .await
         .unwrap();
+        raw_sql(include_str!(
+            "../../../database/migrations/0003_add_authorization_name.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
 
         pool
     }
@@ -520,12 +529,13 @@ mod tests {
         sqlx::query_as::query_as::<_, Authorization>(
             r#"
             INSERT INTO authorizations
-            (stored_key_id, secret, bunker_public_key, bunker_secret, relays, policy_id, max_uses, expires_at, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'), datetime('now'))
+            (stored_key_id, name, secret, bunker_public_key, bunker_secret, relays, policy_id, max_uses, expires_at, created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, datetime('now'), datetime('now'))
             RETURNING *
             "#,
         )
         .bind(stored_key_id)
+        .bind(Option::<String>::None)
         .bind(format!("test_secret_{}", uuid::Uuid::new_v4()))
         .bind(keys.public_key().to_hex())
         .bind(keys.secret_key().to_secret_bytes().to_vec())

--- a/database/migrations/0003_add_authorization_name.sql
+++ b/database/migrations/0003_add_authorization_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE authorizations
+ADD COLUMN name TEXT;

--- a/web/src/lib/components/AuthorizationCard.svelte
+++ b/web/src/lib/components/AuthorizationCard.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
 import type { AuthorizationWithRelations } from "$lib/types";
 import { formattedDateTime } from "$lib/utils/dates";
-import { Check, Copy } from "phosphor-svelte";
+import { Check, Copy, Trash } from "phosphor-svelte";
 import { toast } from "svelte-hot-french-toast";
 
-let { authorization }: { authorization: AuthorizationWithRelations } = $props();
+let {
+    authorization,
+    onRevoke,
+}: {
+    authorization: AuthorizationWithRelations;
+    onRevoke: (authorization: AuthorizationWithRelations) => Promise<void> | void;
+} = $props();
 
 let copyConnectionSuccess = $state(false);
+let isRevoking = $state(false);
 
 function copyConnectionString(authorization: AuthorizationWithRelations) {
     navigator.clipboard.writeText(authorization.bunker_connection_string);
@@ -16,10 +23,26 @@ function copyConnectionString(authorization: AuthorizationWithRelations) {
         copyConnectionSuccess = false;
     }, 2000);
 }
+
+async function revokeAuthorization() {
+    isRevoking = true;
+    try {
+        await onRevoke(authorization);
+    } finally {
+        isRevoking = false;
+    }
+}
 </script>
 
 <div class="card">
-    <h3 class="font-mono text-sm">{authorization.authorization.secret}</h3>
+    {#if authorization.authorization.name}
+        <div>
+            <h3 class="text-lg font-semibold">{authorization.authorization.name}</h3>
+            <p class="font-mono text-xs text-gray-400">{authorization.authorization.secret}</p>
+        </div>
+    {:else}
+        <h3 class="font-mono text-sm">{authorization.authorization.secret}</h3>
+    {/if}
     <button onclick={() => copyConnectionString(authorization)} class="flex flex-row gap-2 items-center justify-center button button-primary button-icon {copyConnectionSuccess ? 'bg-green-600! text-white! ring-green-600!' : ''} transition-all duration-200">
         {#if copyConnectionSuccess}
             <Check size="20" />
@@ -28,6 +51,15 @@ function copyConnectionString(authorization: AuthorizationWithRelations) {
             <Copy size="20" />
             Copy connection string
         {/if}
+    </button>
+    <button
+        type="button"
+        onclick={revokeAuthorization}
+        class="flex flex-row gap-2 items-center justify-center button button-danger button-icon"
+        disabled={isRevoking}
+    >
+        <Trash size="20" />
+        {isRevoking ? "Revoking" : "Revoke authorization"}
     </button>
     <div class="grid grid-cols-[auto_1fr] gap-y-1 gap-x-2 text-xs text-gray-400">
         <span class="whitespace-nowrap">Redemptions:</span>

--- a/web/src/lib/components/SignInMenu.svelte
+++ b/web/src/lib/components/SignInMenu.svelte
@@ -118,7 +118,11 @@ async function startConnectSession(options: ConnectSessionStartOptions) {
                 error instanceof Error ? error.message : "Unable to connect signer";
         }
     } finally {
-        if (connectController === controller) {
+        const shouldClearConnectState =
+            connectController === controller ||
+            (controller.signal.aborted && connectController === null);
+
+        if (shouldClearConnectState) {
             busy = null;
             connectController = null;
         }

--- a/web/src/lib/components/SignInMenu.svelte
+++ b/web/src/lib/components/SignInMenu.svelte
@@ -3,6 +3,7 @@ import {
     createNostrConnectSigninSession,
     hasNip07Extension,
     isAmberSigninSupported,
+    type NostrConnectSigninOptions,
     type NostrConnectSigninSession,
 } from "$lib/nostr";
 import {
@@ -22,7 +23,12 @@ import {
     X,
 } from "phosphor-svelte";
 
-type BusyState = SigninMethod | "nostr-connect-link" | null;
+type BusyState = SigninMethod | "nostr-connect-link" | "amber" | null;
+type ConnectSessionStartOptions = {
+    autoOpen?: boolean;
+    busyState: Exclude<BusyState, null>;
+    signerKind?: NostrConnectSigninOptions["signerKind"];
+};
 
 let open = $state(false);
 let bunkerUri = $state("");
@@ -72,15 +78,33 @@ async function submitBunker(event: SubmitEvent) {
 }
 
 async function startConnectLink() {
+    await startConnectSession({ busyState: "nostr-connect-link" });
+}
+
+async function startAmberConnect() {
+    await startConnectSession({
+        autoOpen: true,
+        busyState: "amber",
+        signerKind: "amber",
+    });
+}
+
+async function startConnectSession(options: ConnectSessionStartOptions) {
     cancelConnectLink();
     connectError = null;
     connectCopied = false;
-    connectSession = createNostrConnectSigninSession();
+    connectSession = createNostrConnectSigninSession({
+        signerKind: options.signerKind,
+    });
     connectUri = connectSession.uri;
 
     const controller = new AbortController();
     connectController = controller;
-    busy = "nostr-connect-link";
+    busy = options.busyState;
+
+    if (options.autoOpen) {
+        openConnectUri(connectUri);
+    }
 
     try {
         const user = await connectSession.waitForUser(controller.signal);
@@ -99,6 +123,10 @@ async function startConnectLink() {
             connectController = null;
         }
     }
+}
+
+function openConnectUri(uri: string) {
+    window.location.href = uri;
 }
 
 function cancelConnectLink() {
@@ -251,19 +279,19 @@ async function copyConnectUri() {
 
                 <button
                     type="button"
-                    onclick={() => runSignin("amber")}
+                    onclick={startAmberConnect}
                     disabled={busy !== null || !amberAvailable}
                     class={signinOptionClass}
                 >
                     <DeviceMobile size="24" />
                     <span class="min-w-0 flex-1">
-                        <span class="block font-medium">Amber</span>
+                        <span class="block font-medium">Connect with Amber</span>
                         <span class="block text-xs text-gray-400">
-                            {amberAvailable ? "Android signer ready" : "Android signer"}
+                            {amberAvailable ? "Nostr Connect ready" : "Android signer"}
                         </span>
                     </span>
                     <span class="text-xs text-gray-500">
-                        {busy === "amber" ? "Opening" : "NIP-55"}
+                        {busy === "amber" ? "Opening" : "NIP-46"}
                     </span>
                 </button>
             </div>

--- a/web/src/lib/nostr.ts
+++ b/web/src/lib/nostr.ts
@@ -8,11 +8,7 @@ import { normalizeToPubkey, npubEncode } from "applesauce-core/helpers";
 import { createEventLoaderForStore } from "applesauce-loaders/loaders";
 import { RelayPool } from "applesauce-relay";
 import type { ISigner } from "applesauce-signers";
-import {
-    AmberClipboardSigner,
-    ExtensionSigner,
-    NostrConnectSigner,
-} from "applesauce-signers";
+import { ExtensionSigner, NostrConnectSigner } from "applesauce-signers";
 import { catchError, filter, firstValueFrom, of, timeout } from "rxjs";
 import {
     DEFAULT_NOSTR_READ_RELAYS,
@@ -39,6 +35,10 @@ export type NostrConnectSigninSession = {
     uri: string;
     waitForUser: (abort?: AbortSignal) => Promise<NostrUser>;
     cancel: () => void;
+};
+export type NostrConnectSigninOptions = {
+    relays?: readonly string[];
+    signerKind?: "nostr-connect" | "amber";
 };
 
 const PROFILE_LOAD_TIMEOUT_MS = 5000;
@@ -95,7 +95,10 @@ export function hasNip07Extension(): boolean {
 }
 
 export function isAmberSigninSupported(): boolean {
-    return Boolean(AmberClipboardSigner.SUPPORTED);
+    return (
+        typeof navigator !== "undefined" &&
+        /\bAndroid\b/i.test(navigator.userAgent)
+    );
 }
 
 export function normalizeBunkerUri(uri: string): string {
@@ -132,10 +135,6 @@ export async function getExtensionUser(): Promise<NostrUser> {
     return userFromSigner(getExtensionSigner(), "extension");
 }
 
-export async function getAmberUser(): Promise<NostrUser> {
-    return userFromSigner(new AmberClipboardSigner(), "amber");
-}
-
 export async function connectNostrConnectBunker(
     bunkerUri: string,
 ): Promise<NostrUser> {
@@ -149,8 +148,10 @@ export async function connectNostrConnectBunker(
 }
 
 export function createNostrConnectSigninSession(
-    relays: readonly string[] = DEFAULT_NOSTR_CONNECT_RELAYS,
+    options: NostrConnectSigninOptions = {},
 ): NostrConnectSigninSession {
+    const relays = options.relays ?? DEFAULT_NOSTR_CONNECT_RELAYS;
+    const signerKind = options.signerKind ?? "nostr-connect";
     const signer = new NostrConnectSigner({
         relays: [...relays],
         pool: relayPool,
@@ -166,7 +167,7 @@ export function createNostrConnectSigninSession(
         uri,
         waitForUser: async (abort?: AbortSignal) => {
             await signer.waitForSigner(abort);
-            return userFromSigner(signer, "nostr-connect");
+            return userFromSigner(signer, signerKind);
         },
         cancel: () => {
             void signer.close();

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -17,6 +17,7 @@ export type User = {
 export type Authorization = {
     id: number;
     stored_key_id: number;
+    name: string | null;
     secret: string;
     bunker_nsec: string;
     relays: string[];

--- a/web/src/lib/utils/auth.ts
+++ b/web/src/lib/utils/auth.ts
@@ -3,15 +3,13 @@ import { getCurrentUser, setCurrentUser } from "$lib/current_user.svelte";
 import {
     clearActiveSigner,
     connectNostrConnectBunker,
-    getAmberUser,
     getExtensionUser,
-    isAmberSigninSupported,
     type NostrUser,
 } from "$lib/nostr";
 import toast from "svelte-hot-french-toast";
 import { checkPubkeyAllowed } from "./allowlist";
 
-export type SigninMethod = "extension" | "nip46-bunker" | "amber";
+export type SigninMethod = "extension" | "nip46-bunker";
 export type SigninOptions = {
     bunkerUri?: string;
 };
@@ -72,12 +70,6 @@ async function userFromSigninMethod(
                     return null;
                 }
                 return connectNostrConnectBunker(options.bunkerUri);
-            case "amber":
-                if (!isAmberSigninSupported()) {
-                    toast.error("Amber sign-in is only available on supported Android browsers");
-                    return null;
-                }
-                return getAmberUser();
             default:
                 method satisfies never;
                 return null;

--- a/web/src/lib/utils/nostr.test.ts
+++ b/web/src/lib/utils/nostr.test.ts
@@ -3,6 +3,7 @@ import type { EventTemplate, NostrEvent } from "applesauce-core/helpers";
 import {
     buildNip46SigningPermissions,
     clearActiveSigner,
+    createNostrConnectSigninSession,
     getActiveSignerSummary,
     npubForPubkey,
     normalizeBunkerUri,
@@ -63,6 +64,18 @@ describe("Nostr helper utilities", () => {
             "get_public_key",
             "sign_event:27235",
         ]);
+    });
+
+    test("creates Amber sign-in sessions through Nostr Connect", () => {
+        const session = createNostrConnectSigninSession({ signerKind: "amber" });
+        const uri = new URL(session.uri);
+
+        session.cancel();
+
+        expect(uri.protocol).toBe("nostrconnect:");
+        expect(uri.searchParams.get("perms")).toBe(
+            "get_public_key,sign_event:27235",
+        );
     });
 
     test("signs events with the active signer", async () => {

--- a/web/src/routes/(app)/teams/[id]/keys/[pubkey]/+page.svelte
+++ b/web/src/routes/(app)/teams/[id]/keys/[pubkey]/+page.svelte
@@ -106,9 +106,10 @@ async function revokeAuthorization(authorization: AuthorizationWithRelations) {
 
     const authorizationId = authorization.authorization.id;
     const endpoint = `/teams/${id}/keys/${pubkey}/authorizations/${authorizationId}`;
-    const authHeader = await api.buildAuthHeader(endpoint, "DELETE", user.pubkey);
 
     try {
+        const authHeader = await api.buildAuthHeader(endpoint, "DELETE", user.pubkey);
+
         await api.delete(endpoint, {
             headers: {
                 Authorization: authHeader,

--- a/web/src/routes/(app)/teams/[id]/keys/[pubkey]/+page.svelte
+++ b/web/src/routes/(app)/teams/[id]/keys/[pubkey]/+page.svelte
@@ -98,6 +98,32 @@ async function removeKey() {
             toast.error("Failed to remove key");
         });
 }
+
+async function revokeAuthorization(authorization: AuthorizationWithRelations) {
+    if (!user?.pubkey) return;
+    if (!confirm("Revoke this authorization? Existing clients using it will lose access."))
+        return;
+
+    const authorizationId = authorization.authorization.id;
+    const endpoint = `/teams/${id}/keys/${pubkey}/authorizations/${authorizationId}`;
+    const authHeader = await api.buildAuthHeader(endpoint, "DELETE", user.pubkey);
+
+    try {
+        await api.delete(endpoint, {
+            headers: {
+                Authorization: authHeader,
+            },
+        });
+
+        authorizations = authorizations.filter(
+            (item) => item.authorization.id !== authorizationId,
+        );
+        toast.success("Authorization revoked");
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        toast.error(`Failed to revoke authorization: ${message}`);
+    }
+}
 </script>
 
 {#if isLoading}
@@ -147,7 +173,10 @@ async function removeKey() {
             {:else}
                 <div class="card-grid">
                     {#each authorizations as authorization}
-                        <AuthorizationCard {authorization} />
+                        <AuthorizationCard
+                            {authorization}
+                            onRevoke={revokeAuthorization}
+                        />
                     {/each}
                 </div>
             {/if}

--- a/web/src/routes/(app)/teams/[id]/keys/[pubkey]/authorizations/new/+page.svelte
+++ b/web/src/routes/(app)/teams/[id]/keys/[pubkey]/authorizations/new/+page.svelte
@@ -23,6 +23,7 @@ const user = $derived(getCurrentUser()?.user);
 let isLoading = $state(true);
 let teamAuthHeader: string | null = $state(null);
 
+let authorizationName = $state("");
 let maxUses: number | null = $state(0);
 let expiresAt: Date | null = $state(null);
 let relaysString: string = $state(relayListForInput());
@@ -79,7 +80,9 @@ async function createAuthorization() {
         return;
     }
 
+    const name = authorizationName.trim();
     const request = {
+        name: name || null,
         max_uses: maxUses === 0 ? null : maxUses,
         expires_at: expiresAt
             ? Math.floor(new Date(expiresAt).getTime() / 1000)
@@ -121,6 +124,16 @@ async function createAuthorization() {
 
 <PageSection title="Authorization">
     <form onsubmit={(event) => { event.preventDefault(); createAuthorization(); }}>
+        <div class="form-group">
+            <label for="authorizationName">Nickname</label>
+            <input
+                id="authorizationName"
+                type="text"
+                maxlength="80"
+                bind:value={authorizationName}
+            />
+        </div>
+
         <div class="form-group">
             <label for="maxUses">Maximum uses (Zero for unlimited)</label>
             <input type="number" bind:value={maxUses} />


### PR DESCRIPTION
## Summary
- route Amber sign-in through the existing Nostr Connect flow and update the button copy
- add optional authorization nicknames with a SQLite migration and UI display
- add API and UI support to revoke authorizations, including scoped backend deletion of redeemed user rows

## Validation
- cargo fmt --check
- cargo check --workspace
- cargo test --workspace (with temporary master.key, removed afterward)
- cd web && bun run check
- cd web && bun test
- cd web && bun run build
- git diff --check
- browser smoke check for app shell/sign-in modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assign nicknames to team key authorizations for clearer identification.
  * Revoke individual authorizations from the UI.

* **Bug Fixes**
  * Authorization nicknames are trimmed and empty values are stored as null.

* **Sign‑in**
  * “Connect with Amber” sign-in flow added with improved session handling.

* **Tests**
  * Expanded coverage for authorization migrations, creation, revocation, and related lifecycle operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/keycast/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->