### PR TITLE
Point production deploys at ghcr.io/marmot-protocol/keycast

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,5 @@ KEYCAST_UID=10001
 KEYCAST_GID=10001
 
 # Image settings used by docker-compose.prod.yml
-KEYCAST_IMAGE=ghcr.io/erskingardner/keycast
+KEYCAST_IMAGE=ghcr.io/marmot-protocol/keycast
 KEYCAST_IMAGE_TAG=master

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN bun install --production --frozen-lockfile
 
 # Final stage
 FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS runtime
-LABEL org.opencontainers.image.source="https://github.com/erskingardner/keycast"
+LABEL org.opencontainers.image.source="https://github.com/marmot-protocol/keycast"
 WORKDIR /app
 
 # Install only the essential runtime dependencies

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ access control matter more than cosmetic cleanup.
 Docker deployment uses:
 
 - `docker-compose.yml` for local source builds of API, web, and signer containers,
-- `docker-compose.prod.yml` for pulling the published `ghcr.io/erskingardner/keycast` image,
+- `docker-compose.prod.yml` for pulling the published `ghcr.io/marmot-protocol/keycast` image,
 - `master.key` mounted into API and signer containers,
 - an external Docker network named `keycast`,
 - Caddy labels for routing `/api/*` to the API and the rest to the web app.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,7 +8,7 @@ install path.
 - Containers now run as a non-root user and use a read-only root filesystem.
 - `master.key` is mounted from the host instead of being copied into the image.
 - `ALLOWED_PUBKEYS` is enforced by the API, not just the browser.
-- `docker-compose.prod.yml` can pull the published `ghcr.io/erskingardner/keycast` image instead of
+- `docker-compose.prod.yml` can pull the published `ghcr.io/marmot-protocol/keycast` image instead of
   building Rust and Bun on the server.
 - The Nostr Rust stack moved to current crates.io releases.
 - Migration `0002_normalize_allowed_kinds_permissions.sql` normalizes old `allowed_kinds` permission
@@ -74,6 +74,10 @@ docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 docker compose -f docker-compose.prod.yml ps
 ```
+
+Production Compose pulls `ghcr.io/marmot-protocol/keycast` by default. If `pull` returns
+`unauthorized`, change the GitHub Packages visibility to public or log the deployment host in to
+GHCR before retrying.
 
 The API and signer run SQLx migrations on startup. The new migration only normalizes old permission
 JSON. It does not rotate keys, change stored-key ciphertext, or invalidate existing bunker connection

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,7 +12,7 @@ services:
   keycast-api:
     <<: *keycast-hardening
     container_name: keycast-api
-    image: ${KEYCAST_IMAGE:-ghcr.io/erskingardner/keycast}:${KEYCAST_IMAGE_TAG:-master}
+    image: ${KEYCAST_IMAGE:-ghcr.io/marmot-protocol/keycast}:${KEYCAST_IMAGE_TAG:-master}
     command: api
     expose:
       - "3000"
@@ -43,7 +43,7 @@ services:
   keycast-web:
     <<: *keycast-hardening
     container_name: keycast-web
-    image: ${KEYCAST_IMAGE:-ghcr.io/erskingardner/keycast}:${KEYCAST_IMAGE_TAG:-master}
+    image: ${KEYCAST_IMAGE:-ghcr.io/marmot-protocol/keycast}:${KEYCAST_IMAGE_TAG:-master}
     command: web
     expose:
       - "5173"
@@ -77,7 +77,7 @@ services:
   keycast-signer:
     <<: *keycast-hardening
     container_name: keycast-signer
-    image: ${KEYCAST_IMAGE:-ghcr.io/erskingardner/keycast}:${KEYCAST_IMAGE_TAG:-master}
+    image: ${KEYCAST_IMAGE:-ghcr.io/marmot-protocol/keycast}:${KEYCAST_IMAGE_TAG:-master}
     command: signer
     volumes:
       - ./database:/app/database:rw


### PR DESCRIPTION
## Summary
- Updated production image defaults to `ghcr.io/marmot-protocol/keycast` in Compose and env examples.
- Switched Docker OCI source metadata and deployment docs to the Marmot Protocol repository URL.
- Added an upgrade note that GHCR must be public or the deploy host must authenticate if pulls return `unauthorized`.

## Testing
- `docker compose -f docker-compose.prod.yml config` renders the new `ghcr.io/marmot-protocol/keycast:master` image for API, web, and signer.
- Verified no stale `erskingardner/keycast` references remain in the repo.
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image repository references to `marmot-protocol/keycast` across production deployment configurations.

* **Documentation**
  * Added troubleshooting guidance for GitHub Packages authentication during deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/keycast/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->